### PR TITLE
adds `filename` (`-n`) option for outputting the filename

### DIFF
--- a/src/aver/Program.fs
+++ b/src/aver/Program.fs
@@ -7,6 +7,7 @@ module AssemblyProperties =
     let [<Literal>] AssemblyVersion = "AssemblyVersion"
     let [<Literal>] ProductVersion = "ProductVersion"
     let [<Literal>] FileVersion = "FileVersion"
+    let [<Literal>] Filename = "Filename"
 
     let default' = [AssemblyVersion]
 
@@ -16,7 +17,8 @@ module AssemblyProperties =
          CompanyName
          AssemblyVersion
          ProductVersion
-         FileVersion]
+         FileVersion
+         Filename]
 
 module Args =
     open Argu
@@ -31,6 +33,7 @@ module Args =
         | [<AltCommandLine("-a")>] Assembly
         | [<AltCommandLine("-p")>] Product
         | [<AltCommandLine("-f")>] File
+        | [<AltCommandLine("-n")>] Filename
         | [<AltCommandLine("-A")>] All
         with
             interface IArgParserTemplate with
@@ -40,6 +43,7 @@ module Args =
                     | Assembly _ -> "Print assembly version"
                     | Product _ -> "Print product version"
                     | File _ -> "Print file version"
+                    | Filename _ -> "Print file name"
                     | All -> "Print whole assembly info"
 
     let parse cliargs =
@@ -56,6 +60,7 @@ module Args =
             getProps [AssemblyProperties.AssemblyVersion] (results.TryGetResult Assembly)
             @ getProps [AssemblyProperties.ProductVersion] (results.TryGetResult Product)
             @ getProps [AssemblyProperties.FileVersion] (results.TryGetResult File)
+            @ getProps [AssemblyProperties.Filename] (results.TryGetResult Filename)
             @ getProps AssemblyProperties.all (results.TryGetResult All)
             |> function
                 | [] -> AssemblyProperties.default'
@@ -81,6 +86,7 @@ module Program =
                     .Add(AssemblyProperties.AssemblyVersion, assembly.GetName().Version.ToString())
                     .Add(AssemblyProperties.ProductVersion, versionInfo.ProductVersion)
                     .Add(AssemblyProperties.FileVersion, versionInfo.FileVersion)
+                    .Add(AssemblyProperties.Filename, options.AssemblyPath)
                 |> Map.filter (fun k _ -> List.contains k options.AssemblyProperties)
 
             Ok map

--- a/test/aver.test/Test.fs
+++ b/test/aver.test/Test.fs
@@ -21,12 +21,14 @@ module Test =
                 .Add(AssemblyProperties.AssemblyVersion, "1.0.0.1")
                 .Add(AssemblyProperties.ProductVersion, "1.0.0.2")
                 .Add(AssemblyProperties.FileVersion, "1.0.0.3")
+                .Add(AssemblyProperties.Filename, "testassembly.dll")
 
         let perParam =
             dict
                 ["-a", (AssemblyProperties.AssemblyVersion, all.[AssemblyProperties.AssemblyVersion])
                  "-p", (AssemblyProperties.ProductVersion,  all.[AssemblyProperties.ProductVersion])
-                 "-f", (AssemblyProperties.FileVersion,     all.[AssemblyProperties.FileVersion])]
+                 "-f", (AssemblyProperties.FileVersion,     all.[AssemblyProperties.FileVersion])
+                 "-n", (AssemblyProperties.Filename,        all.[AssemblyProperties.Filename])]
 
         let mkMap props =
             Seq.fold (fun (s: Map<_,_>) x -> s.Add x) Map.empty props
@@ -50,6 +52,7 @@ module Test =
     [<InlineData("-a")>]
     [<InlineData("-p")>]
     [<InlineData("-f")>]
+    [<InlineData("-n")>]
     let ``one arg should read 1 properties`` (arg1) =
         let args = [|arg1|]
         let options = Args.parse (TestData.mkAverTestArgs args)
@@ -67,6 +70,7 @@ module Test =
     [<InlineData("-a", "-p")>]
     [<InlineData("-a", "-f")>]
     [<InlineData("-p", "-f")>]
+    [<InlineData("-a", "-n")>]
     let ``two args should read 2 properties`` (arg1, arg2) =
         let args = [|arg1; arg2|]
         let options = Args.parse (TestData.mkAverTestArgs args)


### PR DESCRIPTION
Adds the `-n` option which outputs the `Filename`.

This is useful in the scenario when running `aver` as part of a `find` command over a selection of files.